### PR TITLE
fix(security): bump protobuf to 5.29.6 (CVE-2026-0994)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -179,7 +179,7 @@ prettytable==3.9.0
 proglog==0.1.10
 prompt-toolkit==3.0.39
 proto-plus==1.23.0
-protobuf==4.25.3
+protobuf==5.29.6
 psutil==5.9.8
 ptyprocess==0.7.0
 pure-eval==0.2.2


### PR DESCRIPTION
## Summary
- bump protobuf from 4.25.3 to 5.29.6 in requirements.txt
- addresses CVE-2026-0994 / GHSA-7gcm-g887-7qv7 (JSON recursion depth bypass in json_format.ParseDict)

## Why
The previous pinned version is in the affected range. 5.29.6 is the first patched 5.x release.

## Validation
- created a clean venv and installed protobuf==5.29.6 successfully
- smoke test: deeply nested Any payload with json_format.ParseDict(..., max_recursion_depth=50) raises ParseError: Message too deep

## Notes
A README under Grounded-Segment-Anything playground references protobuf==3.19.0 for a specific demo path; this PR only updates the project-wide main requirement for security.
