### PR TITLE
Security: bump Starlette / python-multipart for Dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ aliyun-python-sdk-kms==2.16.3
 altair==5.3.0
 analytics-python==1.4.post1
 annotated-types==0.7.0
+annotated-doc==0.0.4
 antlr4-python3-runtime==4.9.3
 anyio==4.4.0
 asttokens==2.2.1
@@ -47,7 +48,7 @@ email_validator==2.1.1
 exceptiongroup==1.2.1
 executing==1.2.0
 facexlib==0.3.0
-fastapi==0.111.0
+fastapi==0.137.2
 fastapi-cli==0.0.4
 ffmpeg==1.4
 ffmpeg-python==0.2.0
@@ -97,13 +98,17 @@ Jinja2==3.1.2
 jmespath==0.10.0
 joblib==1.3.2
 jsonmerge==1.9.2
+jsonpatch==1.33
 jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
 kiwisolver==1.4.5
 kornia==0.7.0
-langchain==0.0.261
-langchain-experimental==0.0.17
-langsmith==0.0.92
+langchain==0.1.20
+langchain-community==0.0.38
+langchain-core==0.1.53
+langchain-experimental==0.0.58
+langchain-text-splitters==0.0.2
+langsmith==0.1.147
 lapx==0.5.9
 lark==1.1.9
 lazy_loader==0.3
@@ -165,7 +170,7 @@ openxlab==0.1.0
 ordered-set==4.1.0
 orjson==3.10.3
 oss2==2.17.0
-packaging==24.0
+packaging==23.2
 pandas==2.2.1
 paramiko==3.4.0
 parso==0.8.3
@@ -188,8 +193,8 @@ pyasn1-modules==0.3.0
 pycocotools==2.0.7
 pycparser==2.21
 pycryptodome==3.20.0
-pydantic==1.10.9
-pydantic_core==2.18.4
+pydantic==2.13.4
+pydantic_core==2.46.4
 pydub==0.25.1
 Pygments==2.16.1
 PyNaCl==1.5.0
@@ -197,7 +202,7 @@ pyparsing==3.0.9
 PySocks==1.7.1
 python-dateutil==2.8.2
 python-dotenv==1.0.1
-python-multipart==0.0.9
+python-multipart==0.0.32
 pytorch-lightning==2.0.7
 pytorch-ranger==0.1.1
 pytz==2023.4
@@ -207,6 +212,7 @@ referencing==0.35.1
 regex==2023.12.25
 requests==2.32.3
 requests-oauthlib==1.3.1
+requests-toolbelt==1.0.0
 resize-right==0.0.2
 rich==13.4.2
 rpds-py==0.18.1
@@ -219,6 +225,7 @@ scipy==1.11.2
 seaborn==0.13.2
 -e git+https://github.com/IDEA-Research/Grounded-Segment-Anything.git@edf3ed0de347e3922c2fedad8bd3d2ba7861a514#egg=segment_anything&subdirectory=segment_anything
 semantic-version==2.10.0
+setuptools==80.9.0
 sentencepiece==0.2.0
 shellingham==1.5.4
 six==1.16.0
@@ -229,7 +236,7 @@ sounddevice==0.4.6
 soupsieve==2.5
 SQLAlchemy==2.0.29
 stack-data==0.6.2
-starlette==0.37.2
+starlette==1.3.1
 supervision==0.20.0
 sympy==1.12
 tabulate==0.9.0
@@ -261,7 +268,8 @@ transformers==4.26.1
 triton==2.1.0
 typer==0.12.3
 typing-inspect==0.9.0
-typing_extensions==4.12.1
+typing-inspection==0.4.2
+typing_extensions==4.15.0
 tzdata==2024.1
 uc-micro-py==1.0.3
 ujson==5.10.0


### PR DESCRIPTION
starlette 0.37.2→1.3.1 (CVE-2026-54283 / GHSA-82w8-qh3p-5jfq), python-multipart 0.0.9→0.0.32; 连带 fastapi 0.111→0.137.2 / pydantic 1→2 / langchain 0.0.261→0.1.20。已在隔离 Python 3.10 venv 验证: pip check 通过, pip-audit/OSV 0 漏洞, FastAPI Form smoke 通过。注意 pydantic2 + langchain0.1 是破坏性升级, merge 前建议在能运行 DoraemonGPT 的环境确认运行时兼容。